### PR TITLE
Update leakless dir

### DIFF
--- a/leakless.go
+++ b/leakless.go
@@ -102,7 +102,7 @@ func (l *Launcher) serve(uid string) string {
 	return srv.Addr().String()
 }
 
-var leaklessDir = filepath.Join(os.TempDir(), "leakless-"+shared.Version)
+var leaklessDir = filepath.Join(os.TempDir(), fmt.Sprintf("leakless-%s-%s", runtime.GOARCH, shared.Version))
 
 // GetLeaklessBin returns the executable path of the guard, if it doesn't exists create one.
 func GetLeaklessBin() string {


### PR DESCRIPTION
In the current version, arm64 and amd64 share a temporary folder. When initially launched with GOARCH=amd64, a temporary file will be created. Even if it is changed to GOARCH=arm64 afterwards, the amd64 version will still be used for launching, as long as the version is not updated (until the temporary files are manually cleaned or the version is changed).

It is suggested to build the folder name with GOARCH.